### PR TITLE
Fixed script not finding ammo check anims for certain weapons

### DIFF
--- a/gamedata/configs/text/eng/ui_st_ammocheck.xml
+++ b/gamedata/configs/text/eng/ui_st_ammocheck.xml
@@ -49,47 +49,34 @@
     <string id="st_ac_ammoLeft">
         <text>left</text>
     </string>
-
-	
     <string id="ui_mcm_menu_rax_ammo_check">
         <text>Ammo Check</text>
     </string>
     <string id="ui_mm_title_rax_ammo_check">
         <text>Ammo Check</text>
     </string>
-
-	<string id="ui_mcm_rax_ammo_check_usecolor">
-		<text>Color messages.</text>
-	</string>
-
-	<string id="ui_mcm_rax_ammo_check_hidecounter">
-		<text>Hide Ammo Counter.</text>
-	</string>
-
-	<string id="ui_mcm_rax_ammo_check_hideicon">
-		<text>Hide Ammo Icon.</text>
-	</string>
-
-
-	<string id="ui_mcm_rax_ammo_check_busy_hands_fix">
-		<text>Busy Hands Fix.</text>
-	</string>
-	<string id="ui_mcm_rax_ammo_check_busy_hands_fix_desc">
-		<text>Check this box if the Ammo Check "animation" gets stuck. Likely to occur when FDDA is installed</text>
-	</string>
-
-	<string id="ui_mcm_rax_ammo_check_keybind">
-		<text>Ammo Check key.</text>
-	</string>
-
-	<string id="ui_mcm_rax_ammo_check_keybind_desc">
-		<text>This key bind can be configured to require additional modifier keys to mitigate conflicts.</text>
-	</string>
-
-	<string id="ui_mcm_rax_ammo_check_update_mcm">
-		<text>Update MCM to change key bind here. Key defaults to T.</text>
-	</string>
-
-	
-
+    <string id="ui_mcm_rax_ammo_check_usecolor">
+        <text>Color messages.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_hidecounter">
+        <text>Hide Ammo Counter.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_hideicon">
+        <text>Hide Ammo Icon.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_busy_hands_fix">
+        <text>Busy Hands Fix.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_busy_hands_fix_desc">
+        <text>Check this box if the Ammo Check "animation" gets stuck. Likely to occur when FDDA is installed</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_keybind">
+        <text>Ammo Check key.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_keybind_desc">
+        <text>This key bind can be configured to require additional modifier keys to mitigate conflicts.</text>
+    </string>
+    <string id="ui_mcm_rax_ammo_check_update_mcm">
+        <text>Update MCM to change key bind here. Key defaults to T.</text>
+    </string>
 </string_table>

--- a/gamedata/configs/text/rus/ui_st_ammocheck.xml
+++ b/gamedata/configs/text/rus/ui_st_ammocheck.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="windows-1251"?>
 <string_table>
 	<!-- Ammo_Check Messages -->
-	
 	<string id="st_ac_overfull">
 		<text>Переполнен</text>
 	</string>
-     <string id="st_ac_plus1">
-        <text>Полный + 1</text>
-    </string>
-    <string id="st_ac_just_one">
-		<text>Только один</text>
-	</string> 
+	<string id="st_ac_plus1">
+		<text>Полный + 1</text>
+	</string>
+	<string id="st_ac_just_one">
+		<text>Всего один</text>
+	</string>
+	<string id="st_ac_oitc">
+		<text>1 в патроннике</text>
+	</string>
 	<string id="st_ac_full">
 		<text>Полный</text>
 	</string>
@@ -21,7 +23,7 @@
 		<text>Больше половины</text>
 	</string>
 	<string id="st_ac_about_half">
-		<text>Около половины</text>
+		<text>Примерно половина</text>
 	</string>
 	<string id="st_ac_less_half">
 		<text>Меньше половины</text>
@@ -33,61 +35,48 @@
 		<text>Пустой</text>
 	</string>
 	<string id="st_ac_jammed">
-		<text>Оружие заклинило</text>
+		<text>Заклинившее оружие</text>
 	</string>
 	<string id="st_ac_noMag">
 		<text>Магазин не заряжен</text>
 	</string>
+	<string id="st_ac_grenade">
+		<text>Заряжена граната</text>
+	</string>
+	<string id="st_ac_noAmmo">
+		<text>Текущее оружие не стреляет патронами!</text>
+	</string>
 	<string id="st_ac_ammoLeft">
 		<text>осталось</text>
 	</string>
-	<string id="st_ac_noAmmo">
-		<text>Это не использует патроны!</text>
+	<string id="ui_mcm_menu_rax_ammo_check">
+		<text>Проверка патронов</text>
 	</string>
-
-	<string id="kb_check_ammo">
-		<text>Проверить магазин</text>
+	<string id="ui_mm_title_rax_ammo_check">
+		<text>Проверка патронов</text>
 	</string>
-
-    <string id="ui_mcm_menu_rax_ammo_check">
-        <text>Проверка патронов</text>
-    </string>
-    <string id="ui_mm_title_rax_ammo_check">
-        <text>Проверка патронов</text>
-    </string>
-
 	<string id="ui_mcm_rax_ammo_check_usecolor">
-		<text>Цветные сообщения.</text>
+		<text>Цветные сообщения</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_hidecounter">
-		<text>Скрыть счетчик патронов.</text>
+		<text>Спрятать счётчик патронов</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_hideicon">
-		<text>Скрыть значок патронов.</text>
+		<text>Спрятать иконку патронов</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_busy_hands_fix">
-		<text>Исправление занятых рук.</text>
+		<text>Исправление "занятых рук"</text>
 	</string>
 	<string id="ui_mcm_rax_ammo_check_busy_hands_fix_desc">
-		<text>Установите этот флажок, если «анимация» проверки патронов застревает. Вероятно, происходит при установке FDDA</text>
+		<text>Включите, если "анимация" проверки патронов зависает. Высокая вероятность такого события, если установлена модификация FDDA.</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_keybind">
 		<text>Клавиша проверки патронов</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_keybind_desc">
-		<text>Для этой клавиши можно назначить дополнительные клавиши-модификаторы для избежания конфликтов.</text>
+		<text>Этой клавише можно назначить дополнительные модификаторы для избежания конфликтов с другими действиями.</text>
 	</string>
-
 	<string id="ui_mcm_rax_ammo_check_update_mcm">
-		<text>Обновите MCM, чтобы изменить привязку клавиш. Клавиша по умолчанию T.</text>
+		<text>Обновите MCM чтобы назначить клавишу прямо здесь. По умолчанию это будет клавиша T.</text>
 	</string>
-
-
-
-
 </string_table>

--- a/gamedata/scripts/ammo_check_mcm.script
+++ b/gamedata/scripts/ammo_check_mcm.script
@@ -287,7 +287,8 @@ function check_Ammo()
     disable_info("sleep_active")
 
     if not busy_hands_fix then
-		local anm_ammo_check = SYS_GetParam(0, weapon:section() .. "_hud", "anm_ammo_check") 
+		local hud_sec = SYS_GetParam(0, weapon:section(), "hud")
+		anm_ammo_check = hud_sec and SYS_GetParam(0, hud_sec, "anm_ammo_check") or nil
 		if anm_ammo_check then
 			if do_ammo_check_anim then return end -- If an ammo check is already happening, don't do anything
 			

--- a/gamedata/scripts/ammo_check_mcm.script
+++ b/gamedata/scripts/ammo_check_mcm.script
@@ -292,7 +292,7 @@ function check_Ammo()
 		if anm_ammo_check then
 			if do_ammo_check_anim then return end -- If an ammo check is already happening, don't do anything
 			
-			local anm_no_mag_check = SYS_GetParam(0, weapon:section() .. "_hud", "anm_ammo_check_no_mag")
+			local anm_no_mag_check = SYS_GetParam(0, hud_sec, "anm_ammo_check_no_mag")
 			if no_mag_check and (not anm_no_mag_check) then -- if trying to mag check with no mag in gun and there's no "no_mag_check" animation it immediately shows the ammo message without animation
 				message_delay = 0
 			else
@@ -302,7 +302,7 @@ function check_Ammo()
 					do_ammo_check_anim = 1
 					weapon:switch_state(4)
 				else
-					local anm_check_empty = SYS_GetParam(0, weapon:section() .. "_hud", "anm_ammo_check_empty")
+					local anm_check_empty = SYS_GetParam(0, hud_sec, "anm_ammo_check_empty")
 
 					if no_mag_check and anm_no_mag_check then
 						weapon:play_hud_motion("anm_ammo_check_no_mag", true, 0, 1, 0)
@@ -402,8 +402,10 @@ function actor_on_hud_animation_play(anim_table, obj)
 	if valid_anms[anim_table.anm_name] and do_ammo_check_anim == 1 and obj:get_state() == 4 then -- Catch the weapon state switch and do the ammo check animation instead
 		anim_table.anm_speed = 1 -- Assume that the ammo check animation doesn't have a speed set in the ltx
 		
-		local anm_no_mag_check = SYS_GetParam(0, obj:section() .. "_hud", "anm_ammo_check_no_mag")
-		local anm_check_empty = SYS_GetParam(0, obj:section() .. "_hud", "anm_ammo_check_empty")
+        local hud_sec = SYS_GetParam(0, obj:section(), "hud")
+
+		local anm_no_mag_check = SYS_GetParam(0, hud_sec, "anm_ammo_check_no_mag")
+		local anm_check_empty = SYS_GetParam(0, hud_sec, "anm_ammo_check_empty")
 
 		if no_mag_check and anm_no_mag_check then
 			anim_table.anm_name = "anm_ammo_check_no_mag"

--- a/gamedata/scripts/ammo_check_mcm.script
+++ b/gamedata/scripts/ammo_check_mcm.script
@@ -298,7 +298,7 @@ function check_Ammo()
 			else
 				message_delay = 1.5
 				
-				if GAME_VERSION ~= "1.5.1" and false then -- if using 1.5.2 or newer: use actor_on_hud_animation_play callback to catch state switch and play the mag check animation
+				if GAME_VERSION ~= "1.5.1" then -- if using 1.5.2 or newer: use actor_on_hud_animation_play callback to catch state switch and play the mag check animation
 					do_ammo_check_anim = 1
 					weapon:switch_state(4)
 				else
@@ -395,11 +395,13 @@ local valid_anms = {
 	anm_idle_moving_empty = true,
 	anm_idle_sprint_empty = true,
 	anm_bore = true,
-	anm_bore_empty = true
+	anm_bore_empty = true,
+    anm_idle_g = true,
+    anm_idle_w_gl = true
 }
 
 function actor_on_hud_animation_play(anim_table, obj)
-	if valid_anms[anim_table.anm_name] and do_ammo_check_anim == 1 and obj:get_state() == 4 then -- Catch the weapon state switch and do the ammo check animation instead
+	if valid_anms[anim_table.anm_name] and do_ammo_check_anim == 1 then -- Catch the weapon state switch and do the ammo check animation instead
 		anim_table.anm_speed = 1 -- Assume that the ammo check animation doesn't have a speed set in the ltx
 		
         local hud_sec = SYS_GetParam(0, obj:section(), "hud")


### PR DESCRIPTION
Script now properly finds the hud section of weapons, fixing ammo check animations not playing for certain weapons (like SVU)